### PR TITLE
ChatGPT Pull Request Fix

### DIFF
--- a/container.yaml
+++ b/container.yaml
@@ -12,8 +12,50 @@ spec:
       labels:
         run: my-nginx
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
       containers:
         - name: my-nginx
-          image: nginx
+          image: nginx:latest
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            limits:
+              cpu: "1"
+              memory: "500Mi"
+            requests:
+              cpu: "0.5"
+              memory: "250Mi"
           ports:
             - containerPort: 80
+          livenessProbe:
+            httpGet:
+              path: "/"
+              port: 80
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: 80
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d
+              readOnly: true
+          securityContext:
+            seccompProfile:
+              type: "RuntimeDefault"
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: nginx-config


### PR DESCRIPTION
ChatGPT automated fix - apiVersion: apps/v1
kind: Deployment
metadata:
  name: my-nginx
spec:
  selector:
    matchLabels:
      run: my-nginx
  replicas: 2
  template:
    metadata:
      labels:
        run: my-nginx
    spec:
      securityContext:
        runAsUser: 1000
        runAsGroup: 3000
        fsGroup: 2000
      containers:
        - name: my-nginx
          image: nginx:latest
          imagePullPolicy: Always
          securityContext:
            allowPrivilegeEscalation: false
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            capabilities:
              drop:
                - ALL
          resources:
            limits:
              cpu: "1"
              memory: "500Mi"
            requests:
              cpu: "0.5"
              memory: "250Mi"
          ports:
            - containerPort: 80
          livenessProbe:
            httpGet:
              path: "/"
              port: 80
            initialDelaySeconds: 30
            periodSeconds: 10
          readinessProbe:
            httpGet:
              path: "/"
              port: 80
            initialDelaySeconds: 20
            periodSeconds: 10
          volumeMounts:
            - name: nginx-config
              mountPath: /etc/nginx/conf.d
              readOnly: true
          securityContext:
            seccompProfile:
              type: "RuntimeDefault"
      volumes:
        - name: nginx-config
          configMap:
            name: nginx-config